### PR TITLE
LEAN-1550 -- LW - R7:Unable to open the editor for the submissions

### DIFF
--- a/src/DataAccess/ContainerRepository/ContainerRepository.ts
+++ b/src/DataAccess/ContainerRepository/ContainerRepository.ts
@@ -20,6 +20,7 @@ import { SGRepository } from '../SGRepository'
 
 import { IContainerRepository } from '../Interfaces/IContainerRepository'
 import { selectActiveResources } from '../../Utilities/ContainerUtils/selectActiveResources'
+import { proceedWithReadAccess } from '../syncAccessControl'
 
 export abstract class ContainerRepository<Container, ContainerLike, PatchContainer>
   extends SGRepository<Container, ContainerLike, ContainerLike, PatchContainer>
@@ -432,5 +433,9 @@ export abstract class ContainerRepository<Container, ContainerLike, PatchContain
     }
 
     return this.database.bucket.query(Q).then((res: any) => callbackFn(res))
+  }
+
+  public async validateReadAccess(doc: any, userId: string): Promise<void> {
+    await proceedWithReadAccess(doc, userId)
   }
 }

--- a/src/DataAccess/SGRepository.ts
+++ b/src/DataAccess/SGRepository.ts
@@ -129,7 +129,7 @@ export abstract class SGRepository<
             const doc = this.buildModel(res)
             if (userId) {
               try {
-                await this.validate({ ...doc }, { ...doc }, userId)
+                await this.validateReadAccess(doc, userId)
               } catch (e) {
                 return Promise.reject(e)
               }
@@ -450,6 +450,10 @@ export abstract class SGRepository<
           resolve(res)
         })
     })
+  }
+
+  protected async validateReadAccess(doc: any, userId: string): Promise<void> {
+    await this.validate({ ...doc }, { ...doc }, userId)
   }
 
   private validate(doc: any, oldDoc: any, userId?: string): Promise<void> {

--- a/test/suites/unit/DataAccess/SGRepository.spec.ts
+++ b/test/suites/unit/DataAccess/SGRepository.spec.ts
@@ -98,8 +98,8 @@ describe('SGRepository - getById', () => {
     projectRepository.database.bucket.findUnique.mockImplementationOnce((_document: any) =>
       Promise.resolve({ data: project, _id: project._id })
     )
-    const mock = jest.spyOn(syncAccessControl, 'syncAccessControl')
-    mock.mockResolvedValue()
+    const mock = jest.spyOn(syncAccessControl, 'proceedWithReadAccess')
+    mock.mockImplementationOnce(() => Promise.resolve())
 
     const created = await projectRepository.getById(project._id, 'User_foo')
     expect(created._id).toEqual('MPProject:foo')


### PR DESCRIPTION
When getting container document by id from the database it was checking for user write access, with this change it should only check for read access.

Also maintained the old behavior when not dealing with  -- MPProject | MPLibrary | MPLibraryCollection --