### PR TITLE
 LEAN-2553: Fix master's version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.5.3",
+  "version": "1.5.0",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",


### PR DESCRIPTION
There's a wrong version on master, it should be 1.5.0 instead of 1.5.3
I don't think 1.5.3 has been published yet so i think we go back to 1.5.0 
