### PR TITLE
LEAN-2944: save the correct ID when updating the user's role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.5.6-LEAN-2944",
+  "version": "1.5.6-LEAN-2944-V2",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.5.6-MB-LEAN-2944",
+  "version": "1.5.7",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.5.6",
+  "version": "1.5.6-LEAN-2944",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.5.6-LEAN-2944-V2",
+  "version": "1.5.6-MB-LEAN-2944",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/src/Controller/V2/Project/ProjectController.ts
+++ b/src/Controller/V2/Project/ProjectController.ts
@@ -50,7 +50,12 @@ export class ProjectController extends BaseController {
     return new Date(modifiedSince).getTime() / 1000 >= project.updatedAt
   }
 
-  async getProjectModels(types: any, user: Express.User, projectID: string, manuscriptID?: string): Promise<Model[]> {
+  async getProjectModels(
+    types: any,
+    user: Express.User,
+    projectID: string,
+    manuscriptID?: string
+  ): Promise<Model[]> {
     const permissions = await this.getPermissions(projectID, user._id)
     if (!permissions.has(ProjectPermission.READ)) {
       throw new RoleDoesNotPermitOperationError(`Access denied`, user._id)
@@ -69,7 +74,7 @@ export class ProjectController extends BaseController {
   }
 
   async updateUserRole(
-    userID: string,
+    connectUserID: string,
     role: ProjectUserRole,
     user: Express.User,
     projectID: string
@@ -79,7 +84,7 @@ export class ProjectController extends BaseController {
       throw new RoleDoesNotPermitOperationError(`Access denied`, user._id)
     }
 
-    await DIContainer.sharedContainer.projectService.updateUserRole(projectID, userID, role)
+    await DIContainer.sharedContainer.projectService.updateUserRole(projectID, connectUserID, role)
   }
 
   async createManuscript(

--- a/src/DomainServices/ProjectService.ts
+++ b/src/DomainServices/ProjectService.ts
@@ -213,11 +213,11 @@ export class ProjectService {
 
   public async updateUserRole(
     projectID: string,
-    userID: string,
+    connectUserID: string,
     role: ProjectUserRole
   ): Promise<void> {
     const project = await this.getProject(projectID)
-    const user = await this.userRepository.getOne({ connectUserID: userID })
+    const user = await this.userRepository.getOne({ connectUserID: connectUserID })
 
     if (!user) {
       throw new ValidationError('Invalid user id', user)
@@ -237,38 +237,38 @@ export class ProjectService {
 
     const updated = {
       _id: projectID,
-      owners: project.owners.filter((u) => u !== userID && u !== userIdForSync),
-      writers: project.writers.filter((u) => u !== userID && u !== userIdForSync),
-      viewers: project.viewers.filter((u) => u !== userID && u !== userIdForSync),
+      owners: project.owners.filter((u) => u !== connectUserID && u !== userIdForSync),
+      writers: project.writers.filter((u) => u !== connectUserID && u !== userIdForSync),
+      viewers: project.viewers.filter((u) => u !== connectUserID && u !== userIdForSync),
       editors: project.editors
-        ? project.editors.filter((u) => u !== userID && u !== userIdForSync)
+        ? project.editors.filter((u) => u !== connectUserID && u !== userIdForSync)
         : [],
       proofers: project.proofers
-        ? project.proofers.filter((u) => u !== userID && u !== userIdForSync)
+        ? project.proofers.filter((u) => u !== connectUserID && u !== userIdForSync)
         : [],
       annotators: project.annotators
-        ? project.annotators.filter((u) => u !== userID && u !== userIdForSync)
+        ? project.annotators.filter((u) => u !== connectUserID && u !== userIdForSync)
         : [],
     }
 
     switch (role) {
       case ProjectUserRole.Owner:
-        updated.owners.push(userID)
+        updated.owners.push(user._id)
         break
       case ProjectUserRole.Writer:
-        updated.writers.push(userID)
+        updated.writers.push(user._id)
         break
       case ProjectUserRole.Viewer:
-        updated.viewers.push(userID)
+        updated.viewers.push(user._id)
         break
       case ProjectUserRole.Editor:
-        updated.editors.push(userID)
+        updated.editors.push(user._id)
         break
       case ProjectUserRole.Proofer:
-        updated.proofers.push(userID)
+        updated.proofers.push(user._id)
         break
       case ProjectUserRole.Annotator:
-        updated.annotators.push(userID)
+        updated.annotators.push(user._id)
         break
     }
 

--- a/src/DomainServices/ProjectService.ts
+++ b/src/DomainServices/ProjectService.ts
@@ -237,38 +237,38 @@ export class ProjectService {
 
     const updated = {
       _id: projectID,
-      owners: project.owners.filter((u) => u !== connectUserID && u !== userIdForSync),
-      writers: project.writers.filter((u) => u !== connectUserID && u !== userIdForSync),
-      viewers: project.viewers.filter((u) => u !== connectUserID && u !== userIdForSync),
+      owners: project.owners.filter((u) => u !== user._id && u !== userIdForSync),
+      writers: project.writers.filter((u) => u !== user._id && u !== userIdForSync),
+      viewers: project.viewers.filter((u) => u !== user._id && u !== userIdForSync),
       editors: project.editors
-        ? project.editors.filter((u) => u !== connectUserID && u !== userIdForSync)
+        ? project.editors.filter((u) => u !== user._id && u !== userIdForSync)
         : [],
       proofers: project.proofers
-        ? project.proofers.filter((u) => u !== connectUserID && u !== userIdForSync)
+        ? project.proofers.filter((u) => u !== user._id && u !== userIdForSync)
         : [],
       annotators: project.annotators
-        ? project.annotators.filter((u) => u !== connectUserID && u !== userIdForSync)
+        ? project.annotators.filter((u) => u !== user._id && u !== userIdForSync)
         : [],
     }
 
     switch (role) {
       case ProjectUserRole.Owner:
-        updated.owners.push(user._id)
+        updated.owners.push(userIdForSync)
         break
       case ProjectUserRole.Writer:
-        updated.writers.push(user._id)
+        updated.writers.push(userIdForSync)
         break
       case ProjectUserRole.Viewer:
-        updated.viewers.push(user._id)
+        updated.viewers.push(userIdForSync)
         break
       case ProjectUserRole.Editor:
-        updated.editors.push(user._id)
+        updated.editors.push(userIdForSync)
         break
       case ProjectUserRole.Proofer:
-        updated.proofers.push(user._id)
+        updated.proofers.push(userIdForSync)
         break
       case ProjectUserRole.Annotator:
-        updated.annotators.push(user._id)
+        updated.annotators.push(userIdForSync)
         break
     }
 

--- a/test/suites/unit/DomainLayer/ProjectService.spec.ts
+++ b/test/suites/unit/DomainLayer/ProjectService.spec.ts
@@ -426,10 +426,12 @@ describe('projectService', () => {
       expect(userRepository.getOne).toHaveBeenCalledWith({ connectUserID: userID })
 
       expect(containerRepository.patch).toHaveBeenCalledTimes(1)
+
+      const userIdForSync = userID.replace('|', '_')
       expect(containerRepository.patch).toHaveBeenCalledWith(projectID, {
         _id: projectID,
         owners: [validUser2._id],
-        writers: [userID],
+        writers: [userIdForSync],
         viewers: [],
         editors: [],
         annotators: [],


### PR DESCRIPTION
It looks like when updating user roles, we save the connectUserID instead of the userID.  
I also think we need to get rid of userIdForSync, its complicating things. Is there a reason we need it? @mnatsheh 
This is also deployed on dev2 for testing.