### PR TITLE
LEAN-3924: create a manuscriptDoc when we don't have a package uploaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.11.4",
+  "version": "1.11.5-LEAN-3924.0",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/src/Controller/V2/Project/ProjectController.ts
+++ b/src/Controller/V2/Project/ProjectController.ts
@@ -92,8 +92,11 @@ export class ProjectController extends BaseController {
     if (!permissions.has(ProjectPermission.CREATE_MANUSCRIPT)) {
       throw new RoleDoesNotPermitOperationError(`Access denied`, user.id)
     }
-
-    return DIContainer.sharedContainer.projectService.createManuscript(projectID, templateID)
+    return DIContainer.sharedContainer.projectService.createManuscript(
+      projectID,
+      user.id,
+      templateID
+    )
   }
 
   async importJats(

--- a/src/DomainServices/ProjectService.ts
+++ b/src/DomainServices/ProjectService.ts
@@ -140,26 +140,20 @@ export class ProjectService {
     projectID: string,
     userID: string
   ) {
-    console.log('got here')
     const modelMap = DIContainer.sharedContainer.projectService.getContainedModelsMap(
       models as ContainedModel[]
     )
-    console.log('got here 1')
     const article = DIContainer.sharedContainer.projectService.modelMapToManuscriptNode(
       modelMap,
       manuscript._id
     )
-    console.log('got here 2')
     const createDoc: CreateDoc = {
       manuscript_model_id: manuscript._id,
       project_model_id: projectID,
       doc: article,
       schema_version: getVersion(),
     }
-    console.log('got here 3')
-    console.log(userID)
     await DIContainer.sharedContainer.documentClient.createDocument(createDoc, userID)
-    console.log('got here 4')
   }
 
   public async makeArchive(projectID: string, options?: ArchiveOptions) {

--- a/src/DomainServices/ProjectService.ts
+++ b/src/DomainServices/ProjectService.ts
@@ -78,9 +78,9 @@ export class ProjectService {
         throw new MissingTemplateError(templateID)
       }
     }
-    const manuscirpt = await this.projectRepository.createManuscript(projectID, templateID)
-    await this.createManuscriptDoc(Array.of(manuscirpt), manuscirpt, projectID, userID)
-    return manuscirpt
+    const manuscript = await this.projectRepository.createManuscript(projectID, templateID)
+    await this.createManuscriptDoc(Array.of(manuscript), manuscript, projectID, userID)
+    return manuscript
   }
 
   public async importJats(

--- a/test/suites/unit/ControllerLayer/V2/Project/ProjectController.spec.ts
+++ b/test/suites/unit/ControllerLayer/V2/Project/ProjectController.spec.ts
@@ -196,7 +196,7 @@ describe('ProjectController', () => {
         .mockResolvedValue(new Set([ProjectPermission.CREATE_MANUSCRIPT]))
 
       await controller.createManuscript(user, projectID, templateID)
-      expect(projectService.createManuscript).toHaveBeenCalledWith(projectID, templateID)
+      expect(projectService.createManuscript).toHaveBeenCalledWith(projectID, user.id, templateID)
     })
   })
   describe('getUserProfiles', () => {

--- a/test/suites/unit/ControllerLayer/V2/Project/ProjectRoute.spec.ts
+++ b/test/suites/unit/ControllerLayer/V2/Project/ProjectRoute.spec.ts
@@ -296,6 +296,7 @@ describe('ProjectRoute', () => {
     it('should return OK if called correctly', async () => {
       const projectID = createManuscriptRequest.params.projectID
       const templateID = createManuscriptRequest.body.templateID
+      const userID = createManuscriptRequest.user.id
       const permissions = new Set([ProjectPermission.CREATE_MANUSCRIPT])
       projectService.createManuscript = jest.fn().mockResolvedValue({})
       projectService.getPermissions = jest.fn().mockResolvedValue(permissions)
@@ -303,7 +304,7 @@ describe('ProjectRoute', () => {
       // @ts-ignore
       await route.createManuscript(createManuscriptRequest, res)
 
-      expect(projectService.createManuscript).toHaveBeenCalledWith(projectID, templateID)
+      expect(projectService.createManuscript).toHaveBeenCalledWith(projectID, userID, templateID)
       expect(res.status).toHaveBeenCalledWith(StatusCodes.OK)
     })
 

--- a/test/suites/unit/DomainLayer/V2/ProjectService.spec.ts
+++ b/test/suites/unit/DomainLayer/V2/ProjectService.spec.ts
@@ -80,7 +80,10 @@ describe('projectService', () => {
   describe('createManuscript', () => {
     it('should create a new manuscript', async () => {
       projectClient.createManuscript = jest.fn().mockResolvedValue({})
-      await projectService.createManuscript(projectID)
+      projectService['createManuscriptDoc'] = jest.fn()
+
+      await projectService.createManuscript(projectID, userID)
+
       expect(projectClient.createManuscript).toHaveBeenCalled()
     })
     it('should create a new manuscript with the provided templateID', async () => {
@@ -92,8 +95,9 @@ describe('projectService', () => {
 
       configService.hasDocument = jest.fn().mockResolvedValue(true)
       projectClient.createManuscript = jest.fn().mockResolvedValue(expectedManuscript)
+      projectService['createManuscriptDoc'] = jest.fn()
 
-      const result = await projectService.createManuscript(projectID, templateID)
+      const result = await projectService.createManuscript(projectID, userID, templateID)
 
       expect(result).toEqual(expectedManuscript)
       expect(configService.hasDocument).toHaveBeenCalledWith(templateID)
@@ -103,7 +107,8 @@ describe('projectService', () => {
     it('should throw an error if the provided templateID does not exist', async () => {
       configService.hasDocument = jest.fn().mockResolvedValue(false)
       projectClient.createManuscript = jest.fn().mockResolvedValue(null)
-      await expect(projectService.createManuscript(projectID, templateID)).rejects.toThrow(
+      projectService['createManuscriptDoc'] = jest.fn()
+      await expect(projectService.createManuscript(projectID, userID, templateID)).rejects.toThrow(
         new MissingTemplateError(templateID)
       )
       expect(configService.hasDocument).toHaveBeenCalledWith(templateID)


### PR DESCRIPTION
It seems that we create the document on the api now, and we only do that if we go the  [import jats](https://github.com/Atypon-OpenSource/manuscripts-api/blob/642cbba3fd8d3d755ddd708a3eddc0cd21fc6212/src/Controller/V2/Project/ProjectRoute.ts#L252)  route