### PR TITLE
prisma schema changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "1.13.11",
+  "version": "1.13.12",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/prisma/migrations/20241103074038_init/migration.sql
+++ b/prisma/migrations/20241103074038_init/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "MigrationBackup" ADD COLUMN     "id" TEXT;
+UPDATE "MigrationBackup" SET "id" = gen_random_uuid() WHERE "id" IS NULL;

--- a/prisma/migrations/20241103090728_init/migration.sql
+++ b/prisma/migrations/20241103090728_init/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - The primary key for the `MigrationBackup` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Made the column `id` on table `MigrationBackup` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "MigrationBackup" DROP CONSTRAINT "MigrationBackup_pkey",
+ALTER COLUMN "id" SET NOT NULL,
+ADD CONSTRAINT "MigrationBackup_pkey" PRIMARY KEY ("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,8 @@ model ManuscriptDoc {
 }
 
 model MigrationBackup {
-  manuscript_model_id String               @id @default(uuid())
+  id        String                          @id @default(uuid())
+  manuscript_model_id String                @default(uuid())
   user_model_id       String
   project_model_id    String
   doc                 Json


### PR DESCRIPTION
It seems that we've had a couple of issues regarding the last schema change: 
1- it was leaked to master with another merge and published, i believe the latest master published has the migrations. 
2- for some reason prisma doesn't populate default values for newly created columns, i had to modify the sql generated.
3- for all the environments that are affected, we'll either need to run `yarn  prisma migrate resolve --rolled-back  "20241031093413_init"` (mark the migration as rolled back) or delete the migration from the DB 