### PR TITLE
LEAN-5861: JATS export when migrations are run fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "2.3.6",
+  "version": "2.3.7-LEAN-5861.0",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/api",
-  "version": "2.3.7-LEAN-5861.0",
+  "version": "2.3.7",
   "description": "Manuscripts API server",
   "license": "Apache-2.0",
   "main": "dist/index",

--- a/src/DataAccess/maybe-migrate.ts
+++ b/src/DataAccess/maybe-migrate.ts
@@ -33,7 +33,7 @@ async function maybeMigrate(
   if (schema_version === currentVersion) {
     return p
   }
-  const migratedDoc = migrateFor(cloneDeep(doc as JSONProsemirrorNode), schema_version)
+  const migratedDoc = migrateFor(cloneDeep(doc as JSONProsemirrorNode), schema_version).toJSON()
 
   // backing up old doc
   await tx.migrationBackup.create({


### PR DESCRIPTION
## Problem

JATS export throws `RangeError: Invalid input for Fragment.fromJSON` for manuscripts whose stored `schema_version` is older than the current `@manuscripts/transform` version — i.e. exactly the documents that require a migration. Documents already at the current version export fine. The stored DB document is well-formed; this is not a data problem.

Regression from LEAN-5511 (applying migrations when finding the doc).

## Root cause

transform's `migrateFor()` returns `testDoc(...)`, which is a **live ProseMirror `Node`** (its `.content` is a `Fragment` object `{content:[...], size}`), **not** plain JSON. `maybe-migrate.ts` treated that return value as a JSON doc.

Path:
1. `DocumentExtender.findDocument` → `maybeMigrate(found)` (`DocumentExtender.ts:80`).
2. `maybe-migrate.ts:36` `migrateFor(...)` → a `Node`, returned as `doc` (`:60`) and written back to the DB (`:52`).
3. `ProjectService.exportFromManuscript` (`ProjectService.ts:375-377`): `removeSuggestions(model.doc)` is a silent no-op on a `Node` (it guards on `node.content?.length`, and a `Fragment` has no `.length`), then `schema.nodeFromJSON(article)` reads `article.content` — a `Fragment`, truthy but not an array — so `Fragment.fromJSON` throws.

## Fix

Call `.toJSON()` on the migration result so both the returned value and the DB write-back store plain JSON:

```ts
const migratedDoc = migrateFor(cloneDeep(doc as JSONProsemirrorNode), schema_version).toJSON()
```

`maybe-migrate.ts` is the only `migrateFor` caller in this repo, and `migratedDoc` is only used at `:52` (`manuscriptDoc.update`) and `:60` (returned `doc`), both of which expect JSON. transform is left unchanged (its own callers, e.g. `serializeToJATS`, rely on a `Node`).

## Verification

- `tsc --noEmit` error count is identical with and without this change (pre-existing local transform version-mismatch errors only; none in `maybe-migrate.ts`).
- Root cause reproduced in the transform repo: feeding a `migrateFor` result straight into `schema.nodeFromJSON` throws `Invalid input for Fragment.fromJSON`; feeding `migrateFor(...).toJSON()` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)